### PR TITLE
Add support for new fasteignir.visir.is design

### DIFF
--- a/src/visir/property.js
+++ b/src/visir/property.js
@@ -1,15 +1,12 @@
 (function(){
   var price, size, sqPrice, lastRow, newRow;
-  price = cleanPrice($('.b-produtcs-param-price strong').text());
-  size = cleanSize($('.b-house-param li:contains("Stærð") strong').text());
+  price = cleanPrice($('.price').text());
+  size = cleanSize($('.features li:first').text());
   sqPrice = calculateSqPrice(price, size);
+  console.log(sqPrice);
   if (isFinite(sqPrice)) {
-    lastRow = $('.b-house-param ul li:last');
     newRow = $('<li>');
-    newRow.append('<span>Fermetraverð: </span><strong>' + formatPrice(sqPrice) + '</strong>');
-    if (!lastRow.hasClass('styled')) {
-      newRow.addClass('styled');
-    }
-    $('.b-house-param ul').append(newRow);
+    newRow.append('<span class="title">Fermetraverð: </span><span class="data">' + formatPrice(sqPrice) + '</span>');
+    $('ul.loan').append(newRow);
   }
 })();

--- a/src/visir/search.js
+++ b/src/visir/search.js
@@ -34,14 +34,17 @@
     var estateRows = $('.b-products-item-list');
     estateRows.each(function (idx, elem) {
       var $elem = $(elem);
-      var sizeText = $elem.find('.b-products-item-details-param td:contains("Stærð:") strong').text();
-      var priceText = $elem.find('.b-products-item-details-param td:contains("Verð:") strong').text();
+      var sizeText = $elem.find('.b-products-item-details-param td:eq(1)').text();
+      var priceText = $elem.find('.b-products-item-details-param td:eq(0)').text();
 
       var price = cleanPrice(priceText);
       var size = cleanSize(sizeText);
       var sqPrice = calculateSqPrice(price, size);
       if (isFinite(sqPrice)) {
-        $elem.find('.b-products-item-details-param tbody').append('<tr><td colspan=4  style="padding-top:5px;">Fermetraverð: <strong> ' + formatPrice(sqPrice) + ' </strong></td></tr>');
+        var featuresDiv = $elem.find('.b-products-item-details-param');
+        var newElement = $('<div style="font-size: 1.3em; margin: 2px 0px -8px 0;">')
+        newElement.append(`Fermetraverð: <strong>${formatPrice(sqPrice)}</strong>`);
+        featuresDiv.after(newElement);
       }
     });
   });


### PR DESCRIPTION
The elements containing the apartment size and price have changed with a new design from Vísir. This change uses the new elements to display the price per square meter.

Screenshots showing how the price is displayed: 
![screen shot 2016-02-11 at 09 39 31](https://cloud.githubusercontent.com/assets/412623/12973344/9f01dc2c-d0a3-11e5-8df8-ec3acdbd11c7.png)
![screen shot 2016-02-11 at 09 38 52](https://cloud.githubusercontent.com/assets/412623/12973345/a150d1a4-d0a3-11e5-9822-8d393887c3b3.png)
